### PR TITLE
Adding docker to brain-monitor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:10
+# This is throwing an Error Width must be multiple of 2
+RUN apt-get update && apt-get upgrade -y && apt-get autoremove && apt-get autoclean
+RUN apt-get install -y \
+        libhidapi-dev \
+        libblas-dev \
+        liblapack-dev \
+        libmcrypt-dev 
+
+WORKDIR /app
+COPY . /app
+RUN npm install 
+EXPOSE 3000
+CMD ["node", "index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3"
+
+services:
+  brain-monitor_dev:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:3000"
+    volumes:
+      - .:/app


### PR DESCRIPTION
**This is throwing an Error Width must be multiple of 2**. But I'm not able to create a develop branch and a feature branch so you can test it before merge.
You need to have docker, and docker-compose in order to use those files. With a simple 
`docker-compose up` should work this first version.
